### PR TITLE
Reconnect socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,15 @@ Interacting with IGV desktop over a port with IGV batch commands in Python.
 
 ## Pre-requisite
 
-A running IGV with proper authorization
+- Installation
+
+```
+git clone https://github.com/getzlab/igv_remote.git
+cd igv_remote
+pip install .
+```
+
+Please make sure your IGV is running with proper authorization (to access controlled-access files)
 
 ## Usage
 
@@ -28,7 +36,7 @@ ir.connect()
 
 # set view params
 ir.set_saveopts(img_dir = "igv_snapshots/", img_basename = "test.png" ) # must be set!
-ir.set_viewopts(view_type="collapsed", viewaspairs = True, sort = "base" ) # optional, this view options will be passed to all view panels
+ir.set_viewopts(view_type="collapsed", sort = "base" ) # optional, this view options will be passed to all view panels
 
 # load views / snapshot
 ir.load(<tumor_bam>, <normal_bam>, ...)

--- a/examples/batch_igv.py
+++ b/examples/batch_igv.py
@@ -16,7 +16,7 @@ df = df[df.if_match == 1]
 # set up igv_remote
 ir.connect()
 ir.set_saveopts(img_dir = "igv_snapshots", img_basename = "sv.png" ) # must be set!
-ir.set_viewopts(view_type = "collapsed", viewaspairs = False, sort = "base") # optional
+ir.set_viewopts(view_type = "collapsed", sort = "base") # optional
 prev_tumor = ""
 print(df)
 

--- a/examples/run.py
+++ b/examples/run.py
@@ -10,8 +10,12 @@ import igv_remote as ir
 ir.connect()
 
 # set some view/save params
-ir.set_saveopts(img_dir = "igv_snapshots/", img_basename = "test.png" ) # must be set!
-ir.set_viewopts(collapse = False, squish = True, viewaspairs = True, sort = "base" ) # optional
+# save options are needed only if you are taking snapshots
+# the following config will allow you to save snapshots to '$(pwd)/igv_snapshots/test_0.png'
+ir.set_saveopts(img_dir = "igv_snapshots/", img_basename = "test.png" ) 
+
+# view options are used to configure the appearance of IGV, the defualt would be:
+ir.set_viewopts(view_type = 'collapsed', sort = "base" ) # optional
 
 # single bam snapshots
 sample_gspath = "gs://..."

--- a/igv_remote/_core.py
+++ b/igv_remote/_core.py
@@ -28,8 +28,9 @@ def _parse_loc(chromosome, pos1, pos2=None, expand=20):
 class IGV_remote:
     sock=None
     
-    def __init__(self):
+    def __init__(self, view_type='collapsed', sort='base'): 
         self.sock = None
+        self._set_viewopts(view_type=view_type, sort=sort)
     
     def _set_saveopts(self, img_dir, img_basename, img_init_id=0) :
         # check if path is absolute and exits
@@ -37,7 +38,7 @@ class IGV_remote:
             print("Initializing a directory called {} in current dir".format(img_dir))
             os.mkdir(img_dir)
         img_fulldir = os.path.abspath(img_dir)
-        
+        print("Snapshots are available in {}".format(img_fulldir))
         # check if the image name has proper extension
         accepted_extensions = ["png", "svg", "jpg"]
         if not any(x in img_basename for x in accepted_extensions):
@@ -64,10 +65,10 @@ class IGV_remote:
 
     def _send(self, cmd):
         assert self.sock is not None
-        with self.sock as s:
-            cmd = cmd + '\n'
-            s.send(cmd.encode('utf-8'))
-            s.recv(2000).decode('utf-8').rstrip('\n')
+        s=self.sock
+        cmd = cmd + '\n'
+        s.send(cmd.encode('utf-8'))
+        s.recv(2000).decode('utf-8').rstrip('\n')
     
     def _load(self, *urls):
         print(urls)
@@ -81,13 +82,6 @@ class IGV_remote:
 
     def _adjust_viewopts(self):
         
-	# make sure view_opts have been set
-        try:
-            self._view_type
-        except:
-            print("View options hasn't been set, using the default [view_type='collapsed', sort='base']")
-            self._set_viewopts(view_type = 'collapsed', sort = 'base')
-	
         # specify view options
         if self._view_type == "squished":
             self._send( "squish ")
@@ -136,7 +130,7 @@ class IGV_remote:
         self._send("goto {}".format(" ".join(positions)))
 
     def _snapshot(self):
-        assert self._image_fulldir is not None,"Please set view optins with ir.set_saveopts() first"
+        assert self._image_fulldir is not None, "Please set view optins with ir.set_saveopts() first"
         self._send( "snapshotDirectory %s" % self._img_fulldir)
         newname = _append_id(self._img_basename, self._img_id)
         self._send( "snapshot %s" % newname)


### PR DESCRIPTION
This PR moves socket init to `connect` and will hopefully solve #7. This PR also removes `viewaspair` option in `set_viewopts` since there is no port command to revert such operation. It is recommended to use mouse clicks to more flexibly change whether one wants to view alignments as pairs. Thanks again to @ZiaoLIN for pointing this issue out!